### PR TITLE
Ya misspelled ya goon

### DIFF
--- a/cartpole.py
+++ b/cartpole.py
@@ -1,5 +1,5 @@
 import gym
-from deepq import Agent
+from DeepQ import Agent
 from utils import plot_learning_curve
 import numpy as np
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+gym
+DeepQ
+numpy
+matplotlib
+tensorflow


### PR DESCRIPTION
`deepq` -> `DeepQ`

Added a `requirements.txt`, because you gotta. No version though because I don't know what you need. Plus M1 Macs don't have an install media for Tensorflow, so I couldn't actually get it to work. Ya did it again, Apple